### PR TITLE
Adicionado exportacao das classes para uso do nome do modulo

### DIFF
--- a/Observer.ts
+++ b/Observer.ts
@@ -1,4 +1,0 @@
-export interface Observer
-{
-    update(data:any): this
-}

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,1 @@
-import {Observer} from "./Observer"
-import {Subject} from "./Subject"
+export * from './src/index'

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,18 @@
 # ts-observer-pattern
 A simple observer pattern implementation in TypeScript.  
 
-```npm install ts-observer-pattern```
+```
+npm install ts-observer-pattern
+```
 
-# Example
+## Example
 
 In the example that follows, I'm implementing a relationship bettween a magazine and it subscribers
 
-```
+```TypeScript
+// Magazine.ts
+import { Subject } from 'ts-observer-pattern'
+
 class Magazine extends Subject
 {
     private Observers: Observers[]
@@ -21,7 +26,10 @@ class Magazine extends Subject
 }
 ```
 
-```
+```TypeScript
+// Subscriber.ts
+import { Observer } from 'ts-observer-pattern'
+
 class Subscriber implements Observer
 {
     public update(data): this
@@ -31,7 +39,11 @@ class Subscriber implements Observer
 }
 ```
 
-```
+```TypeScript
+// main.ts
+import { Magazine } from './Magazine'
+import { Subscriber } from './Subscriber'
+
 let Coders = new Magazine
 
 let Matt = new Subscriber

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -1,0 +1,4 @@
+export default interface Observer
+{
+    update(data:any): this
+}

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -1,5 +1,6 @@
-import { Observer } from "./Observer"
-export abstract class Subject
+import Observer from "./Observer"
+
+export default abstract class Subject
 {
     protected observers: Observer[]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+import Observer from "./Observer"
+import Subject from "./Subject"
+
+export { Observer, Subject }


### PR DESCRIPTION
- Movido classes para pasta _src_
- Adicionado recurso de exportação no arquivo `index.ts` para permitir o uso das classes com referência apenas ao nome do módulo.